### PR TITLE
Compatible with cargo --remap-path-prefix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,5 +10,5 @@ fn main() {
         panic!("i128 support was not detected!");
     }
 
-    autocfg::rerun_path(file!());
+    autocfg::rerun_path("build.rs");
 }


### PR DESCRIPTION
As discussed in [num-traits issue 139](https://github.com/rust-num/num-traits/issues/139).