### PR TITLE
Drop unused `autocfg` build dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,3 @@ std = ["num-integer/std", "num-traits/std"]
 
 # vestigial features, now always in effect
 i128 = []
-
-[build-dependencies]
-autocfg = "1"


### PR DESCRIPTION
This crate declares a build dependency on `autocfg`, but it doesn't seem to contain any build script so the dependency is useless.